### PR TITLE
記事詳細表示機能

### DIFF
--- a/app/assets/stylesheets/pages/_article_detail.scss
+++ b/app/assets/stylesheets/pages/_article_detail.scss
@@ -182,6 +182,9 @@
 .article-item-list {
   display: flex;
   width: 100%;
+  &__eyecatch {
+    margin-left: auto;
+  }
 
   &__body {
     display: flex;

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -21,7 +21,7 @@ class ArticlesController < ApplicationController
   def show
     @article = Article.find(params[:id])
     user = @article.user
-    @user_articles = user.articles.where.not(id: @article.id)
+    @user_articles = user.articles.where.not(id: @article.id).order(created_at: :desc)
   end
 
   private

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,7 +2,7 @@ class ArticlesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @articles = Article.includes(:user).article_sorted
+    @articles = Article.includes(:user).created_at_desc_sort
   end
 
   def new

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,7 +2,7 @@ class ArticlesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @articles = Article.includes(:user).sorted
+    @articles = Article.includes(:user).article_sorted
   end
 
   def new

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -18,6 +18,12 @@ class ArticlesController < ApplicationController
     end
   end
 
+  def show
+    @article = Article.find(params[:id])
+    user = @article.user
+    @user_articles = user.articles.where.not(id: @article.id)
+  end
+
   private
 
   def article_params

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,7 +2,7 @@ class ArticlesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @articles = Article.includes(:user).order(created_at: :desc)
+    @articles = Article.includes(:user).sorted
   end
 
   def new
@@ -20,8 +20,8 @@ class ArticlesController < ApplicationController
 
   def show
     @article = Article.find(params[:id])
-    user = @article.user
-    @user_articles = user.articles.where.not(id: @article.id).order(created_at: :desc)
+    post_user = @article.user
+    @user_articles = @article.not_selected_articles(post_user)
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,10 +22,10 @@ class Article < ApplicationRecord
     buy_setting == true
   end
 
-  scope :sorted, -> { order(created_at: :desc) }
+  scope :article_sorted, -> { order(created_at: :desc) }
 
   def not_selected_articles(post_user)
-    post_user.articles.where.not(id: self.id).sorted
+    post_user.articles.where.not(id: self.id).article_sorted
   end
 
   def previous(post_article)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -23,12 +23,12 @@ class Article < ApplicationRecord
     buy_setting == true
   end
 
-  def previous
-    Article.where("id > ?", self.id).order("id DESC").first
+  def previous(post_article)
+    post_article.user.articles.where("id > ?", post_article.id).order("id DESC").first
   end
 
-  def next
-    Article.where("id < ?", self.id).order("id DESC").first
+  def next(post_article)
+    post_article.user.articles.where("id < ?", post_article.id).order("id DESC").first
   end
 
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,7 +12,6 @@ class Article < ApplicationRecord
   # validates :buy_setting  boolean型にしているため、presence: trueだと、falseのときにエラーになる
 
   # validates :price, presence: true, if: :not_free?  これでifの制限つけれる
-
   with_options presence: true, if: :not_free? do
     validates :price, numericality: { only_integer: true, with: /\A[0-9]+\z/, message: 'は半角数字で入力してください', allow_blank: true }
     validates_inclusion_of :price, in: 100..9_999_999, message: 'は¥100〜9,999,999に設定してください', allow_blank: true
@@ -21,6 +20,12 @@ class Article < ApplicationRecord
   
   def not_free?
     buy_setting == true
+  end
+
+  scope :sorted, -> { order(created_at: :desc) }
+
+  def not_selected_articles(post_user)
+    post_user.articles.where.not(id: self.id).sorted
   end
 
   def previous(post_article)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,6 @@
 class Article < ApplicationRecord
+  belongs_to :user
+  has_one_attached :image
 
   with_options presence: true do
     validates :image
@@ -21,6 +23,12 @@ class Article < ApplicationRecord
     buy_setting == true
   end
 
-  belongs_to :user
-  has_one_attached :image
+  def previous
+    Article.where("id > ?", self.id).order("id DESC").first
+  end
+
+  def next
+    Article.where("id < ?", self.id).order("id DESC").first
+  end
+
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,10 +22,10 @@ class Article < ApplicationRecord
     buy_setting == true
   end
 
-  scope :article_sorted, -> { order(created_at: :desc) }
+  scope :created_at_desc_sort, -> { order(created_at: :desc) }
 
   def not_selected_articles(post_user)
-    post_user.articles.where.not(id: self.id).article_sorted
+    post_user.articles.where.not(id: self.id).created_at_desc_sort
   end
 
   def previous(post_article)

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -11,7 +11,7 @@
             <%= article.title %>
           <h3>
           <p class="article-list-item__description">
-            <%= article.text.truncate(10) %>
+            <%= article.text.truncate(30) %>
           </p>
           <div class="article-list-item__status_container">
             <div class="article-list-item__status article-list-item__status--like">

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -11,7 +11,7 @@
             <%= article.title %>
           <h3>
           <p class="article-list-item__description">
-            <%= article.text %>
+            <%= article.text.truncate(10) %>
           </p>
           <div class="article-list-item__status_container">
             <div class="article-list-item__status article-list-item__status--like">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -4,29 +4,31 @@
     <article class="article-detail-item__body">
       <div class="article-detail-content">
         <figure class="article-eyecatch">
-          <%= image_tag "apple.jpg", class: "a-image article-eyecatch__image" %>
+          <%= image_tag @article.image, class: "a-image article-eyecatch__image" %>
         </figure>
         <div class="article-detail-content__body">
-          <h1 class="article-detail-content__title">ああああああああああああああああああああ</h1>
+          <h1 class="article-detail-content__title"><%= @article.title %></h1>
           <div class="article-detail-content__status">
             <div class="article-detail-content__like">
               <%= icon("far", "heart", class: "a-icon a-icon--heart a-icon--small") %>
               <span class="article-detail-content__likeCount">1</span>
             </div>
-            <div class="article-detail-content__priceBox">
-              <%= icon("fas", "yen-sign", class: "a-icon a-icon--price a-icon--small") %>
-              <span class="article-detail-content__price">110</span>
-            </div>
+            <% if @article.buy_setting == true %>
+              <div class="article-detail-content__priceBox">
+                <%= icon("fas", "yen-sign", class: "a-icon a-icon--price a-icon--small") %>
+                <span class="article-detail-content__price"><%= @article.price %></span>
+              </div>
+            <% end %>
           </div>
           <div class="article-detail-content__author">
             <div class="article-detail-content__info">
               <div class="article-detail-content__name">
                 <a href="#" class="a-link article-detail-cotent__link">
-                  ああああ
+                  <%= @article.user.nickname %>
                 </a>
               </div>
               <span class="article-detail-content__date">
-                <time>2020/12/2317:00</time>
+                <time><%= time_ago_in_words(@article.created_at, include_seconds: true) %>前</time>
               </span>
             </div>
             <div class="article-detail-content__status">
@@ -43,7 +45,7 @@
                       <li class="a-display__basicListItem">
                         <a href="#" class="a-display__link">削除する</a>
                       </li>
-                     </ul>
+                    </ul>
                   </div>
                 </div>
               </div>
@@ -51,7 +53,7 @@
           </div>
           <div class="article-detail-text">
             <div class="article-detail-text__body">
-              <p>ああああああああああああああああああああああああああ</p>
+              <p><%= @article.text %></p>
             </div>
           </div>
         </div>
@@ -68,17 +70,17 @@
               <div class="article-paySaleWall__content">
                 <div class="article-paySaleWall__itemDetail">
                   <h3 class="article-paySaleWall__itemTitle">
-                    ああああああああああああああああああああ
+                    <%= @article.text %>
                   </h3>
                   <div class="article-paySaleWall__itemName">
-                    ああああ
+                    <%= @article.user.nickname %>
                   </div>
                   <p class="article-paySaleWall__itemPrice">
-                    <span>100円</span>
+                    <span><%= @article.price %></span>
                   </p>
                 </div>
                 <div class="article-paySaleWall__itemImage">
-                  <%= image_tag "apple.jpg", class: "a-image article-paySaleWall__itemImageSrc" %>
+                  <%= image_tag @article.image, class: "a-image article-paySaleWall__itemImageSrc" %>
                 </div>
               </div>
               <div class="article-paySaleWall__itemAction">
@@ -144,7 +146,7 @@
       <div class="article-account-follow">
         <div class="account-follow-content">
           <p class="account-follow-sentense">
-            <span class="account-follow-sentense__authorName">ああああ</span>さんをフォローしますか？
+            <span class="account-follow-sentense__authorName"><%= @article.user.nickname %></span>さんをフォローしますか？
           </p>
           <div class="account-follow-content__btn">
             <a href="#" class="a-btn account-follow-content__btn--link">
@@ -166,108 +168,44 @@
     </article>
     <div class="article-related-content">
       <h2 class="article-related-content__title">
-        ああああさんのその他の記事
+        <%= @article.user.nickname %>のその他の記事
       </h2>
       <div class="article-related-content__body">
-        <div class="article-related-content__item">
-          <section class="article-item-list">
-            <a href="#" class="a-link">
-              <div class="article-item-list__body">
-                <div class="article-item-list__item">
-                  <h3 class="article-item-list__title">
-                    あああああああああああああああああああああああああああああああああああああ
-                  </h3>
-                  <div class="article-item-list__detail">
-                    <div class="article-item-list__like">
-                      <span class="article-item-list__icon">
-                        <%= icon("far", "heart" , class: "a-icon a-icon--heart a-icon--small") %>
-                      </span>
-                      <span class="article-item-list__likeCount">
-                        144
-                      </span>
-                    </div>
-                    <div class="article-item-list__creatorName">
-                      <a href="#" class="a-link">
-                        ああああ
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="article-item-list__eyecatch">
-                <figure class="article-item-list__eyecatchImage a-eyecatch a-eyecatch--medium">
-                  <%= image_tag "apple.jpg", class: "a-image a-eyecatch__image"%>
-                </figure>
-              </div>
-            </a>
-          </section>
-        </div>
-        <div class="article-related-content__item">
-          <section class="article-item-list">
-            <a href="#" class="a-link">
-              <div class="article-item-list__body">
-                <div class="article-item-list__item">
-                  <h3 class="article-item-list__title">
-                    あああああああああああああああああああああああああああああああああああああ
-                  </h3>
-                  <div class="article-item-list__detail">
-                    <div class="article-item-list__like">
-                      <span class="article-item-list__icon">
-                        <%= icon("far", "heart" , class: "a-icon a-icon--heart a-icon--small") %>
-                      </span>
-                      <span class="article-item-list__likeCount">
-                        144
-                      </span>
-                    </div>
-                    <div class="article-item-list__creatorName">
-                      <a href="#" class="a-link">
-                        ああああ
-                      </a>
+        <% @user_articles.each do |user_article| %>
+          <div class="article-related-content__item">
+            <section class="article-item-list">
+              <a href="#" class="a-link">
+                <div class="article-item-list__body">
+                  <div class="article-item-list__item">
+                    <h3 class="article-item-list__title">
+                      <%= user_article.title %>
+                    </h3>
+                    <div class="article-item-list__detail">
+                      <div class="article-item-list__like">
+                        <span class="article-item-list__icon">
+                          <%= icon("far", "heart" , class: "a-icon a-icon--heart a-icon--small") %>
+                        </span>
+                        <span class="article-item-list__likeCount">
+                          144
+                        </span>
+                      </div>
+                      <div class="article-item-list__creatorName">
+                        <a href="#" class="a-link">
+                          <%= user_article.user.nickname %>
+                        </a>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div class="article-item-list__eyecatch">
-                <figure class="article-item-list__eyecatchImage a-eyecatch a-eyecatch--medium">
-                  <%= image_tag "apple.jpg", class: "a-image a-eyecatch__image"%>
-                </figure>
-              </div>
-            </a>
-          </section>
-        </div>
-        <div class="article-related-content__item">
-          <section class="article-item-list">
-            <a href="#" class="a-link">
-              <div class="article-item-list__body">
-                <div class="article-item-list__item">
-                  <h3 class="article-item-list__title">
-                    あああああああああああああああああああああああああああああああああああああ
-                  </h3>
-                  <div class="article-item-list__detail">
-                    <div class="article-item-list__like">
-                      <span class="article-item-list__icon">
-                        <%= icon("far", "heart" , class: "a-icon a-icon--heart a-icon--small") %>
-                      </span>
-                      <span class="article-item-list__likeCount">
-                        144
-                      </span>
-                    </div>
-                    <div class="article-item-list__creatorName">
-                      <a href="#" class="a-link">
-                        ああああ
-                      </a>
-                    </div>
-                  </div>
+                <div class="article-item-list__eyecatch">
+                  <figure class="article-item-list__eyecatchImage a-eyecatch a-eyecatch--medium">
+                    <%= image_tag user_article.image, class: "a-image a-eyecatch__image"%>
+                  </figure>
                 </div>
-              </div>
-              <div class="article-item-list__eyecatch">
-                <figure class="article-item-list__eyecatchImage a-eyecatch a-eyecatch--medium">
-                  <%= image_tag "apple.jpg", class: "a-image a-eyecatch__image"%>
-                </figure>
-              </div>
-            </a>
-          </section>
-        </div>
+              </a>
+            </section>
+          </div>
+        <% end %>
       </div>
     </div>
     <div class="article-item-sibling">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -23,9 +23,9 @@
           <div class="article-detail-content__author">
             <div class="article-detail-content__info">
               <div class="article-detail-content__name">
-                <a href="#" class="a-link article-detail-cotent__link">
+                <%= link_to "#", class: "a-link article-detail-cotent__link" do %><%# user#showにとばす %>
                   <%= @article.user.nickname %>
-                </a>
+                <% end %>
               </div>
               <span class="article-detail-content__date">
                 <time><%= time_ago_in_words(@article.created_at, include_seconds: true) %>前</time>
@@ -33,17 +33,17 @@
             </div>
             <div class="article-detail-content__status">
               <div class="article-detail-content__actionList">
-                <a href="#" class="a-link article-detail-content__actionListLink" id="js-showPage-ellipse">
+                <%= link_to "#", class: "a-link article-detail-content__actionListLink", id: "js-showPage-ellipse" do %><%# 編集削除ボタンだすとこ %>
                   <%= icon("fas", "ellipsis-h", class: "a-icon a-icon--ellipse") %>
-                </a>
+                <% end %>
                 <div class="a-display a-display--arrow_top display_none" id="js-showPage-display">
                   <div class="a-display__body a-display__body--articleShowPage">
                     <ul class="a-display__basicLists">
                       <li class="a-display__basicListItem a-display__basicListItem--not">
-                        <a href="/articles/:id/edit" class="a-display__link">編集する</a>
+                        <%= link_to "編集する", "#", class: "a-display__link" %>
                       </li>
                       <li class="a-display__basicListItem">
-                        <a href="#" class="a-display__link">削除する</a>
+                        <%= link_to "削除する", "#", class: "a-display__link" %>
                       </li>
                     </ul>
                   </div>
@@ -89,11 +89,11 @@
                   </div>
                 </div>
                 <div class="article-paySaleWall__itemAction">
-                  <a href="/articles/:article_id/user_deals" class="a-btn">
+                  <%= link_to "#", class: "a-btn" do %>
                     <div class="a-btn__inner">
                       購入する
                     </div>
-                  </a>
+                  <% end %>
                 </div>
               </div>
             </div>
@@ -104,31 +104,31 @@
         <div class="article-detail-hashtagGroup">
           <ul class="article-detail-hashtagGroup__body">
             <li class="article-detail-hashtagGroup__item">
-              <a href="#" class="article-detail-hashtag__link a-link a-tag__link">
+              <%= link_to "#", class: "article-detail-hashtag__link a-link a-tag__link" do %>
                 <div class="a-tag a-tag--small">
                   <div class="a-tag__label">
                     #今週のおすすめ
                   </div>
                 </div>
-              </a>
+              <% end %>
             </li>
             <li class="article-detail-hashtagGroup__item">
-              <a href="#" class="article-detail-hashtag__link a-link a-tag__link">
+              <%= link_to "#", class: "article-detail-hashtag__link a-link a-tag__link" do %>
                 <div class="a-tag a-tag--small">
                   <div class="a-tag__label">
                     #今週のおすすめ
                   </div>
                 </div>
-              </a>
+              <% end %>
             </li>
             <li class="article-detail-hashtagGroup__item">
-              <a href="#" class="article-detail-hashtag__link a-link a-tag__link">
+              <%= link_to "#", class: "article-detail-hashtag__link a-link a-tag__link" do %>
                 <div class="a-tag a-tag--small">
                   <div class="a-tag__label">
                     #今週のおすすめ
                   </div>
                 </div>
-              </a>
+              <% end %>
             </li>
           </ul>
         </div>
@@ -136,16 +136,16 @@
       <div class="article-detail-action">
         <div class="article-detail-action__btns">
           <div class="article-detail-action__btn">
-            <a href="#" class="a-link">
+            <%= link_to "#", class: "a-btn" do %>
               <%= icon("far", "heart", class: "a-icon a-icon--heart a-icon--medium")%>
-            </a>
+            <% end %>
           </div>
           <div class="article-detail-action__btn article-detail-action__btn--alert">
-            <a href="#" class="a-btn a-btn--alert a-btn article-detail-action__btn--link">
+            <%= link_to "#", class: "a-btn a-btn--alert a-btn article-detail-action__btn--link" do %>
               <div class="a-btn__inner a-btn__inner--small">
                 記事を報告する
               </div>
-            </a>
+            <% end %>
           </div>
         </div>
       </div>
@@ -155,11 +155,11 @@
             <span class="account-follow-sentense__authorName"><%= @article.user.nickname %></span>さんをフォローしますか？
           </p>
           <div class="account-follow-content__btn">
-            <a href="#" class="a-btn account-follow-content__btn--link">
+            <%= link_to "#", class: "a-btn account-follow-content__btn--link" do %>
               <div class="a-btn__inner">
                 フォロー
               </div>
-            </a>
+            <% end %>
           </div>
         </div>
       </div>
@@ -180,7 +180,7 @@
         <% @user_articles.each do |user_article| %>
           <div class="article-related-content__item">
             <section class="article-item-list">
-              <a href="#" class="a-link">
+              <%= link_to article_path(user_article), class: "a-link" do %>
                 <div class="article-item-list__body">
                   <div class="article-item-list__item">
                     <h3 class="article-item-list__title">
@@ -196,9 +196,9 @@
                         </span>
                       </div>
                       <div class="article-item-list__creatorName">
-                        <a href="#" class="a-link">
+                        <%= link_to "#", class: "a-link" do %><%# user#show %>
                           <%= user_article.user.nickname %>
-                        </a>
+                        <% end %>
                       </div>
                     </div>
                   </div>
@@ -208,7 +208,7 @@
                     <%= image_tag user_article.image, class: "a-image a-eyecatch__image"%>
                   </figure>
                 </div>
-              </a>
+              <% end %>
             </section>
           </div>
         <% end %>
@@ -217,16 +217,20 @@
     <div class="article-item-sibling">
       <nav class="article-item-sibling__nav">
         <div class="article-item-sibling__prev">
-          <a href="#" class="article-item-sibling__link article-item-sibling__link--prev a-link">
-            <%= icon("fas", "angle-left", class: "a-icon a-icon--prev a-icon--medium") %>
-            <div class="article-item-sibling__label">いいいいいいいいいいいいい</div>
-          </a>
+          <% if @article.previous.present? %>
+            <%= link_to article_path(@article.previous), class: "article-item-sibling__link article-item-sibling__link--prev a-link" do %>
+              <%= icon("fas", "angle-left", class: "a-icon a-icon--prev a-icon--medium") %>
+              <div class="article-item-sibling__label"><%= @article.previous.title %></div>
+            <% end %>
+          <% end %>
         </div>
         <div class="article-item-sibling__next">
-          <a href="#" class="article-item-sibling__link article-item-sibling__link--next a-link">
-            <div class="article-item-sibling__label">ううううううううううううう</div>
-            <%= icon("fas", "angle-right", class: "a-icon a-icon--next a-icon--medium") %>
-          </a>
+          <% if @article.next.present? %>
+            <%= link_to article_path(@article.next), class: "article-item-sibling__link article-item-sibling__link--next a-link" do %>
+              <div class="article-item-sibling__label"><%= @article.next.title %></div>
+              <%= icon("fas", "angle-right", class: "a-icon a-icon--next a-icon--medium") %>
+            <% end %>
+          <% end %>
         </div>
       </nav>
     </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -54,7 +54,7 @@
           <div class="article-detail-text">
             <div class="article-detail-text__body">
               <% if @article.buy_setting == true %>
-                <p><%= @article.text.truncate(10) %></p>
+                <p><%= @article.text.truncate(30) %></p>
               <% else %>
                 <p><%= @article.text %></p>
               <% end %>
@@ -75,7 +75,7 @@
                 <div class="article-paySaleWall__content">
                   <div class="article-paySaleWall__itemDetail">
                     <h3 class="article-paySaleWall__itemTitle">
-                      <%= @article.text.truncate(10) %>
+                      <%= @article.text.truncate(30) %>
                     </h3>
                     <div class="article-paySaleWall__itemName">
                       <%= @article.user.nickname %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -217,17 +217,17 @@
     <div class="article-item-sibling">
       <nav class="article-item-sibling__nav">
         <div class="article-item-sibling__prev">
-          <% if @article.previous.present? %>
-            <%= link_to article_path(@article.previous), class: "article-item-sibling__link article-item-sibling__link--prev a-link" do %>
+          <% if @article.previous(@article).present? %>
+            <%= link_to article_path(@article.previous(@article)), class: "article-item-sibling__link article-item-sibling__link--prev a-link" do %>
               <%= icon("fas", "angle-left", class: "a-icon a-icon--prev a-icon--medium") %>
-              <div class="article-item-sibling__label"><%= @article.previous.title %></div>
+              <div class="article-item-sibling__label"><%= @article.previous(@article).title %></div>
             <% end %>
           <% end %>
         </div>
         <div class="article-item-sibling__next">
-          <% if @article.next.present? %>
-            <%= link_to article_path(@article.next), class: "article-item-sibling__link article-item-sibling__link--next a-link" do %>
-              <div class="article-item-sibling__label"><%= @article.next.title %></div>
+          <% if @article.next(@article).present? %>
+            <%= link_to article_path(@article.next(@article)), class: "article-item-sibling__link article-item-sibling__link--next a-link" do %>
+              <div class="article-item-sibling__label"><%= @article.next(@article).title %></div>
               <%= icon("fas", "angle-right", class: "a-icon a-icon--next a-icon--medium") %>
             <% end %>
           <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -53,47 +53,53 @@
           </div>
           <div class="article-detail-text">
             <div class="article-detail-text__body">
-              <p><%= @article.text %></p>
+              <% if @article.buy_setting == true %>
+                <p><%= @article.text.truncate(10) %></p>
+              <% else %>
+                <p><%= @article.text %></p>
+              <% end %>
             </div>
           </div>
         </div>
       </div>
-      <section class="article-pay-wall">
-        <div class="article-pay-wallHeader">
-          <h2 class="article-pay-wallHeader__title">
-            この続きは購入すると見れます！
-          </h2>
-        </div>
-        <section class="article-pay-wall__item">
-          <div class="article-paySaleWall">
-            <div class="article-paySaleWall__inner">
-              <div class="article-paySaleWall__content">
-                <div class="article-paySaleWall__itemDetail">
-                  <h3 class="article-paySaleWall__itemTitle">
-                    <%= @article.text %>
-                  </h3>
-                  <div class="article-paySaleWall__itemName">
-                    <%= @article.user.nickname %>
+      <% if @article.buy_setting == true %>
+        <section class="article-pay-wall">
+          <div class="article-pay-wallHeader">
+            <h2 class="article-pay-wallHeader__title">
+              この続きは購入すると見れます！
+            </h2>
+          </div>
+          <section class="article-pay-wall__item">
+            <div class="article-paySaleWall">
+              <div class="article-paySaleWall__inner">
+                <div class="article-paySaleWall__content">
+                  <div class="article-paySaleWall__itemDetail">
+                    <h3 class="article-paySaleWall__itemTitle">
+                      <%= @article.text.truncate(10) %>
+                    </h3>
+                    <div class="article-paySaleWall__itemName">
+                      <%= @article.user.nickname %>
+                    </div>
+                    <p class="article-paySaleWall__itemPrice">
+                      <span><%= @article.price %></span>
+                    </p>
                   </div>
-                  <p class="article-paySaleWall__itemPrice">
-                    <span><%= @article.price %></span>
-                  </p>
-                </div>
-                <div class="article-paySaleWall__itemImage">
-                  <%= image_tag @article.image, class: "a-image article-paySaleWall__itemImageSrc" %>
-                </div>
-              </div>
-              <div class="article-paySaleWall__itemAction">
-                <a href="/articles/:article_id/user_deals" class="a-btn">
-                  <div class="a-btn__inner">
-                    購入する
+                  <div class="article-paySaleWall__itemImage">
+                    <%= image_tag @article.image, class: "a-image article-paySaleWall__itemImageSrc" %>
                   </div>
-                </a>
+                </div>
+                <div class="article-paySaleWall__itemAction">
+                  <a href="/articles/:article_id/user_deals" class="a-btn">
+                    <div class="a-btn__inner">
+                      購入する
+                    </div>
+                  </a>
+                </div>
               </div>
             </div>
-          </div>
+          </section>
         </section>
-      </section>
+      <% end %>
       <div class="article-detail-hashtags">
         <div class="article-detail-hashtagGroup">
           <ul class="article-detail-hashtagGroup__body">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -33,8 +33,10 @@
             </div>
             <div class="article-detail-content__status">
               <div class="article-detail-content__actionList">
-                <%= link_to "#", class: "a-link article-detail-content__actionListLink", id: "js-showPage-ellipse" do %><%# 編集削除ボタンだすとこ %>
-                  <%= icon("fas", "ellipsis-h", class: "a-icon a-icon--ellipse") %>
+                <% if user_signed_in? && current_user.id == @article.user.id %>
+                  <%= link_to "#", class: "a-link article-detail-content__actionListLink", id: "js-showPage-ellipse" do %>
+                    <%= icon("fas", "ellipsis-h", class: "a-icon a-icon--ellipse") %>
+                  <% end %>
                 <% end %>
                 <div class="a-display a-display--arrow_top display_none" id="js-showPage-display">
                   <div class="a-display__body a-display__body--articleShowPage">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -55,7 +55,7 @@
           </div>
           <div class="article-detail-text">
             <div class="article-detail-text__body">
-              <% if @article.buy_setting == true %>
+              <% if @article.buy_setting == true && @article.user != current_user %>
                 <p><%= @article.text.truncate(30) %></p>
               <% else %>
                 <p><%= @article.text %></p>
@@ -64,7 +64,7 @@
           </div>
         </div>
       </div>
-      <% if @article.buy_setting == true %>
+      <% if @article.buy_setting == true && @article.user != current_user %>
         <section class="article-pay-wall">
           <div class="article-pay-wallHeader">
             <h2 class="article-pay-wallHeader__title">


### PR DESCRIPTION
# What
記事詳細表示機能の実装

# Why
topページの記事一覧から記事の詳細画面に繊維できるようにするため

無料記事（ログアウトしてます）
<img width="938" alt="スクリーンショット 2021-02-23 1 03 55" src="https://user-images.githubusercontent.com/54060301/108734637-0164bc80-7573-11eb-82ae-552e44e4d2a8.png">

有料記事（投稿者がログイン）
<img width="935" alt="スクリーンショット 2021-02-23 1 04 53" src="https://user-images.githubusercontent.com/54060301/108734779-25280280-7573-11eb-9ef5-d2a8508779d0.png">
